### PR TITLE
remove graphrag from requirement.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -206,4 +206,3 @@ wrapt==1.16.0
 xxhash==3.5.0
 yarl==1.10.0
 zipp==3.20.1
-graphrag==0.3.2


### PR DESCRIPTION
Based on the discussion, we are removing graphrag for now, and it may be added later in a separate requirements.txt file dedicated for a specific notebook.