### PR TITLE
updated the requirements.txt to include chromadb which is needed for …

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,7 @@ botocore==1.35.14
 catalogue==2.0.10
 certifi==2024.8.30
 charset-normalizer==3.3.2
+chromadb==0.5.15
 click==8.1.7
 cloudpathlib==0.19.0
 cohere==5.9.1


### PR DESCRIPTION
…the reliable_rag.ipynb notebook

The chromadb is needed for the reliable_rag notebook, so would be good to include it in the requirements.txt