### PR TITLE
we needed to append the system path before the import of the helper_f…

### DIFF
--- a/all_rag_techniques_runnable_scripts/simple_rag.py
+++ b/all_rag_techniques_runnable_scripts/simple_rag.py
@@ -3,11 +3,12 @@ import sys
 import argparse
 import time
 from dotenv import load_dotenv
-from helper_functions import *
-from evaluation.evalute_rag import *
 
 # Add the parent directory to the path since we work with notebooks
 sys.path.append(os.path.abspath(os.path.join(os.getcwd(), '..')))
+
+from helper_functions import *
+from evaluation.evalute_rag import *
 
 # Load environment variables from a .env file (e.g., OpenAI API key)
 load_dotenv()


### PR DESCRIPTION
python simple_rag.py                         
Traceback (most recent call last):
  File "/Users/justin/dev/RAG_Techniques-fork/all_rag_techniques_runnable_scripts/simple_rag.py", line 6, in <module>
    from helper_functions import *
ModuleNotFoundError: No module named 'helper_functions'

Tested on MacOS
When not having the 
sys.path.append(os.path.abspath(os.path.join(os.getcwd(), '..')))

BEFORE the

from helper_functions import *
from evaluation.evalute_rag import *

I would receive the "ModuleNotFoundError" error. After the fix, the script ran as intended.