### PR TITLE
Fixed pydantic import in reliable_rag.ipynb

### DIFF
--- a/all_rag_techniques/reliable_rag.ipynb
+++ b/all_rag_techniques/reliable_rag.ipynb
@@ -239,7 +239,7 @@
    "outputs": [],
    "source": [
     "from langchain_core.prompts import ChatPromptTemplate\n",
-    "from langchain_core.pydantic_v1 import BaseModel, Field\n",
+    "from pydantic import BaseModel, Field\n",
     "from langchain_groq import ChatGroq\n",
     "\n",
     "# Data model\n",


### PR DESCRIPTION
#### **Error Message**

While running the Highlighting block, the following error was encountered
```
AttributeError: type object 'HighlightDocuments' has no attribute 'model_json_schema'
```

#### **Change made**

Modified the imports in `reliable_rag.ipynb` 
```python
# Change from this:
from langchain_core.pydantic_v1 import BaseModel, Field

# To this:
from pydantic import BaseModel, Field  # Works with latest Pydantic
```

