### PR TITLE
Replace Service Context, Removed dotenv-python from requirements, Changed chromadb version to 0.5.3

### DIFF
--- a/all_rag_techniques/choose_chunk_size.ipynb
+++ b/all_rag_techniques/choose_chunk_size.ipynb
@@ -9,7 +9,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -19,7 +19,7 @@
     "nest_asyncio.apply()\n",
     "from dotenv import load_dotenv\n",
     "\n",
-    "from llama_index.core import VectorStoreIndex, SimpleDirectoryReader, ServiceContext\n",
+    "from llama_index.core import VectorStoreIndex, SimpleDirectoryReader\n",
     "from llama_index.core.prompts import PromptTemplate\n",
     "\n",
     "from llama_index.core.evaluation import (\n",
@@ -28,6 +28,7 @@
     "    RelevancyEvaluator\n",
     ")\n",
     "from llama_index.llms.openai import OpenAI\n",
+    "from llama_index.core import Settings\n",
     "\n",
     "import openai\n",
     "import time\n",
@@ -91,10 +92,10 @@
     "gpt4 = OpenAI(temperature=0, model=\"gpt-4o\")\n",
     "\n",
     "# Define service context for GPT-4 for evaluation\n",
-    "service_context_gpt4 = ServiceContext.from_defaults(llm=gpt4)\n",
+    "Settings.llm = gpt4\n",
     "\n",
     "# Define Faithfulness and Relevancy Evaluators which are based on GPT-4\n",
-    "faithfulness_gpt4 = FaithfulnessEvaluator(service_context=service_context_gpt4)\n",
+    "faithfulness_gpt4 = FaithfulnessEvaluator()\n",
     "\n",
     "faithfulness_new_prompt_template = PromptTemplate(\"\"\" Please tell if a given piece of information is directly supported by the context.\n",
     "    You need to answer with either YES or NO.\n",
@@ -123,7 +124,7 @@
     "    \"\"\")\n",
     "\n",
     "faithfulness_gpt4.update_prompts({\"your_prompt_key\": faithfulness_new_prompt_template}) # Update the prompts dictionary with the new prompt template\n",
-    "relevancy_gpt4 = RelevancyEvaluator(service_context=service_context_gpt4)"
+    "relevancy_gpt4 = RelevancyEvaluator()"
    ]
   },
   {
@@ -159,10 +160,10 @@
     "    # create vector index\n",
     "    llm = OpenAI(model=\"gpt-3.5-turbo\")\n",
     "\n",
-    "    service_context = ServiceContext.from_defaults(llm=llm, chunk_size=chunk_size, chunk_overlap=chunk_size//5)  \n",
-    "    vector_index = VectorStoreIndex.from_documents(\n",
-    "        eval_documents, service_context=service_context\n",
-    "    )\n",
+    "    Settings.llm = llm\n",
+    "    Settings.chunk_size = chunk_size\n",
+    "    Settings.chunk_overlap = chunk_size // 5    \n",
+    "    vector_index = VectorStoreIndex.from_documents(eval_documents)\n",
     "    # build query engine\n",
     "    query_engine = vector_index.as_query_engine(similarity_top_k=5)\n",
     "    num_questions = len(eval_questions)\n",
@@ -203,26 +204,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "C:\\Users\\N7\\AppData\\Local\\Temp\\ipykernel_22672\\1178342312.py:21: DeprecationWarning: Call to deprecated class method from_defaults. (ServiceContext is deprecated, please use `llama_index.settings.Settings` instead.) -- Deprecated since version 0.10.0.\n",
-      "  service_context = ServiceContext.from_defaults(llm=llm, chunk_size=chunk_size, chunk_overlap=chunk_size//5)\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Chunk size 128 - Average Response time: 1.35s, Average Faithfulness: 1.00, Average Relevancy: 1.00\n",
-      "Chunk size 256 - Average Response time: 1.31s, Average Faithfulness: 1.00, Average Relevancy: 1.00\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "chunk_sizes = [128, 256]\n",
     "\n",
@@ -234,7 +218,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": ".venv",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -248,7 +232,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.0"
+   "version": "3.11.0"
   }
  },
  "nbformat": 4,

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ botocore==1.35.14
 catalogue==2.0.10
 certifi==2024.8.30
 charset-normalizer==3.3.2
-chromadb==0.5.15
+chromadb==0.5.3
 click==8.1.7
 cloudpathlib==0.19.0
 cohere==5.9.1
@@ -36,7 +36,6 @@ dill==0.3.8
 dirtyjson==1.0.8
 distro==1.9.0
 docx2txt==0.8
-dotenv-python==0.0.1
 enum34==1.1.10
 exceptiongroup==1.2.2
 execnet==2.1.1


### PR DESCRIPTION
Fix for Issue #77

The usage of llama_index.core.ServiceContext is now deprecated in LlamaIndex. The official documentation recommends switching to llama_index.core.Settings

Two more issues pertaining to the requirements.txt affecting other notebooks:

1. dotenv-python overwriting python-dotenv in pip resulting in the following error:

```python
ImportError: cannot import name 'load_dotenv' from 'dotenv' (unknown location)
```

Solution: Remove `dotenv-python` from `requirements.txt`

2. `chromadb==0.5.15` causing vectorstore to crash python kernel during its invoking in reliable-rag.ipynb 
    and possibly others importing from Chroma.

Solution: Change version to `chromadb==0.5.3` in `requirements.txt`


I have added these two changes part of this PR since I believe they are too minute to warrant their own PR. If I should remove these changes and only fix the aforementioned issue, I am ready to revert to only the changes specified in the issue. Please let me know if the following changes work. Thank you