### PR TITLE
RAG with ollama support

### DIFF
--- a/all_rag_techniques/simple_csv_rag.ipynb
+++ b/all_rag_techniques/simple_csv_rag.ipynb
@@ -17,6 +17,9 @@
     "\n",
     "This code implements a basic Retrieval-Augmented Generation (RAG) system for processing and querying CSV documents. The system encodes the document content into a vector store, which can then be queried to retrieve relevant information.\n",
     "\n",
+    "## Alternative: Running locally with Ollama\n",
+    "Using Ollama, we can run this script without any API keys or credits on your personal computer using the small Llama3.2 model with just 2GB of memory. For more details on running Ollama, refer https://github.com/NirDiamant/agents-towards-production/blob/main/tutorials/on-prem-llm-ollama/ollama_tutorial.ipynb\n",
+    "\n",
     "# CSV File Structure and Use Case\n",
     "The CSV file contains dummy customer data, comprising various attributes like first name, last name, company, etc. This dataset will be utilized for a RAG use case, facilitating the creation of a customer information Q&A system.\n",
     "\n",
@@ -103,6 +106,24 @@
     "llm = ChatOpenAI(model=\"gpt-3.5-turbo-0125\")"
    ]
   },
+  {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Alternative: Running with Ollama model and embeddings locally"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from langchain_community.document_loaders.csv_loader import CSVLoader\n",
+        "from langchain_ollama import ChatOllama, OllamaEmbeddings\n",
+        "llm = ChatOllama(model=\"llama3.2\")"
+      ]
+    },
   {
    "cell_type": "markdown",
    "metadata": {},
@@ -334,6 +355,35 @@
     "    index_to_docstore_id={}\n",
     ")"
    ]
+  },
+  {
+    "cell_type": "markdown",
+    "metadata": {},
+    "source": [
+      "## Alternative: Running with Ollama Embeddings"
+    ]
+  },
+  {
+    "cell_type": "code",
+    "execution_count": null,
+    "metadata": {},
+    "outputs": [],
+    "source": [
+      "import faiss\n",
+      "from langchain_community.docstore.in_memory import InMemoryDocstore\n",
+      "from langchain_community.vectorstores import FAISS\n",
+      "# Initialize Ollama embeddings\n",
+      "embeddings = OllamaEmbeddings(model=\"mxbai-embed-large\")  # or another embedding model you have locally\n",
+      "# Create FAISS index using embedding dimension\n",
+      "index = faiss.IndexFlatL2(len(embeddings.embed_query(\" \")))\n",
+      "# Create FAISS vector store\n",
+      "vector_store = FAISS(\n",
+      "    embedding_function=embeddings,\n",
+      "    index=index,\n",
+      "    docstore=InMemoryDocstore(),\n",
+      "    index_to_docstore_id={},\n",
+      ")"
+    ]
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
I assume multiple readers of this repository such as myself do not have access to OpenAI, Groq or Anthropic's API keys and don't want to spend money on them. Further, many organizations, such as the one I work in, would prefer our models do not share our proprietary data to OpenAI. A local model would come in clutch in such scenarios.

Has been tested on my macos 15 (M1 Macbook Air) laptop.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added local model execution capability, enabling users to work with an alternative workflow that operates entirely without API keys or external service dependencies.

* **Documentation**
  * Added instructional content and tutorial references to guide users through setup and usage of the new local workflow alternative.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->