### PR TITLE
feat: add multi-provider LLM support with MiniMax M3 integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -558,6 +558,33 @@ To begin implementing these advanced RAG techniques in your projects:
    ```
 3. Follow the detailed implementation guide in each technique's directory.
 
+## Multi-Provider LLM Support
+
+The `helper_functions.py` module includes a `get_langchain_chat_model()` factory function that lets you easily switch between different LLM providers:
+
+| Provider | Enum Value | Default Model | Required Environment Variable |
+|----------|------------|---------------|-------------------------------|
+| OpenAI | `ModelProvider.OPENAI` | `gpt-4o` | `OPENAI_API_KEY` |
+| Groq | `ModelProvider.GROQ` | `llama-3.3-70b-versatile` | `GROQ_API_KEY` |
+| Anthropic | `ModelProvider.ANTHROPIC` | `claude-sonnet-4-20250514` | `ANTHROPIC_API_KEY` |
+| Amazon Bedrock | `ModelProvider.AMAZON_BEDROCK` | `anthropic.claude-3-sonnet-20240229-v1:0` | AWS credentials |
+| MiniMax | `ModelProvider.MINIMAX` | `MiniMax-M1` | `MINIMAX_API_KEY` |
+
+**Example usage:**
+
+```python
+from helper_functions import ModelProvider, get_langchain_chat_model
+
+# Use OpenAI (default)
+llm = get_langchain_chat_model(ModelProvider.OPENAI)
+
+# Use MiniMax
+llm = get_langchain_chat_model(ModelProvider.MINIMAX, model="MiniMax-M1")
+
+# Use Anthropic with custom settings
+llm = get_langchain_chat_model(ModelProvider.ANTHROPIC, temperature=0.7, max_tokens=2000)
+```
+
 ## Contributing
 
 We welcome contributions from the community! If you have a new technique or improvement to suggest:

--- a/README.md
+++ b/README.md
@@ -568,7 +568,7 @@ The `helper_functions.py` module includes a `get_langchain_chat_model()` factory
 | Groq | `ModelProvider.GROQ` | `llama-3.3-70b-versatile` | `GROQ_API_KEY` |
 | Anthropic | `ModelProvider.ANTHROPIC` | `claude-sonnet-4-20250514` | `ANTHROPIC_API_KEY` |
 | Amazon Bedrock | `ModelProvider.AMAZON_BEDROCK` | `anthropic.claude-3-sonnet-20240229-v1:0` | AWS credentials |
-| MiniMax | `ModelProvider.MINIMAX` | `MiniMax-M1` | `MINIMAX_API_KEY` |
+| MiniMax | `ModelProvider.MINIMAX` | `MiniMax-M2.7` | `MINIMAX_API_KEY` |
 
 **Example usage:**
 
@@ -579,7 +579,7 @@ from helper_functions import ModelProvider, get_langchain_chat_model
 llm = get_langchain_chat_model(ModelProvider.OPENAI)
 
 # Use MiniMax
-llm = get_langchain_chat_model(ModelProvider.MINIMAX, model="MiniMax-M1")
+llm = get_langchain_chat_model(ModelProvider.MINIMAX, model="MiniMax-M2.7")
 
 # Use Anthropic with custom settings
 llm = get_langchain_chat_model(ModelProvider.ANTHROPIC, temperature=0.7, max_tokens=2000)

--- a/README.md
+++ b/README.md
@@ -568,7 +568,7 @@ The `helper_functions.py` module includes a `get_langchain_chat_model()` factory
 | Groq | `ModelProvider.GROQ` | `llama-3.3-70b-versatile` | `GROQ_API_KEY` |
 | Anthropic | `ModelProvider.ANTHROPIC` | `claude-sonnet-4-20250514` | `ANTHROPIC_API_KEY` |
 | Amazon Bedrock | `ModelProvider.AMAZON_BEDROCK` | `anthropic.claude-3-sonnet-20240229-v1:0` | AWS credentials |
-| MiniMax | `ModelProvider.MINIMAX` | `MiniMax-M2.7` | `MINIMAX_API_KEY` |
+| MiniMax | `ModelProvider.MINIMAX` | `MiniMax-M3` | `MINIMAX_API_KEY` |
 
 **Example usage:**
 
@@ -578,8 +578,8 @@ from helper_functions import ModelProvider, get_langchain_chat_model
 # Use OpenAI (default)
 llm = get_langchain_chat_model(ModelProvider.OPENAI)
 
-# Use MiniMax
-llm = get_langchain_chat_model(ModelProvider.MINIMAX, model="MiniMax-M2.7")
+# Use MiniMax (defaults to MiniMax-M3; pass model="MiniMax-M2.7" for the previous generation)
+llm = get_langchain_chat_model(ModelProvider.MINIMAX)
 
 # Use Anthropic with custom settings
 llm = get_langchain_chat_model(ModelProvider.ANTHROPIC, temperature=0.7, max_tokens=2000)

--- a/helper_functions.py
+++ b/helper_functions.py
@@ -333,6 +333,64 @@ class ModelProvider(Enum):
     GROQ = "groq"
     ANTHROPIC = "anthropic"
     AMAZON_BEDROCK = "bedrock"
+    MINIMAX = "minimax"
+
+
+def get_langchain_chat_model(provider: ModelProvider, model: str = None, temperature: float = 0, max_tokens: int = 4000):
+    """
+    Returns a LangChain chat model based on the specified provider.
+
+    Args:
+        provider (ModelProvider): The model provider to use.
+        model (str): Optional - The specific model ID to use.
+        temperature (float): The temperature for generation (default: 0).
+        max_tokens (int): Maximum tokens for generation (default: 4000).
+
+    Returns:
+        A LangChain chat model instance.
+
+    Raises:
+        ValueError: If the specified provider is not supported.
+    """
+    if provider == ModelProvider.OPENAI:
+        from langchain_openai import ChatOpenAI
+        return ChatOpenAI(
+            model=model or "gpt-4o",
+            temperature=temperature,
+            max_tokens=max_tokens,
+        )
+    elif provider == ModelProvider.GROQ:
+        from langchain_groq import ChatGroq
+        return ChatGroq(
+            model=model or "llama-3.3-70b-versatile",
+            temperature=temperature,
+            max_tokens=max_tokens,
+        )
+    elif provider == ModelProvider.ANTHROPIC:
+        from langchain_anthropic import ChatAnthropic
+        return ChatAnthropic(
+            model=model or "claude-sonnet-4-20250514",
+            temperature=temperature,
+            max_tokens=max_tokens,
+        )
+    elif provider == ModelProvider.AMAZON_BEDROCK:
+        from langchain_aws import ChatBedrock
+        return ChatBedrock(
+            model_id=model or "anthropic.claude-3-sonnet-20240229-v1:0",
+            model_kwargs={"temperature": temperature, "max_tokens": max_tokens},
+        )
+    elif provider == ModelProvider.MINIMAX:
+        from langchain_openai import ChatOpenAI
+        import os
+        return ChatOpenAI(
+            model=model or "MiniMax-M1",
+            temperature=temperature if temperature > 0 else 0.1,
+            max_tokens=max_tokens,
+            openai_api_key=os.environ.get("MINIMAX_API_KEY"),
+            openai_api_base="https://api.minimax.io/v1",
+        )
+    else:
+        raise ValueError(f"Unsupported model provider: {provider}")
 
 
 def get_langchain_embedding_provider(provider: EmbeddingProvider, model_id: str = None):

--- a/helper_functions.py
+++ b/helper_functions.py
@@ -383,7 +383,7 @@ def get_langchain_chat_model(provider: ModelProvider, model: str = None, tempera
         from langchain_openai import ChatOpenAI
         import os
         return ChatOpenAI(
-            model=model or "MiniMax-M1",
+            model=model or "MiniMax-M2.7",
             temperature=temperature if temperature > 0 else 0.1,
             max_tokens=max_tokens,
             openai_api_key=os.environ.get("MINIMAX_API_KEY"),

--- a/helper_functions.py
+++ b/helper_functions.py
@@ -383,7 +383,7 @@ def get_langchain_chat_model(provider: ModelProvider, model: str = None, tempera
         from langchain_openai import ChatOpenAI
         import os
         return ChatOpenAI(
-            model=model or "MiniMax-M2.7",
+            model=model or "MiniMax-M3",
             temperature=temperature if temperature > 0 else 0.1,
             max_tokens=max_tokens,
             openai_api_key=os.environ.get("MINIMAX_API_KEY"),


### PR DESCRIPTION
## Summary
- Add multi-provider LLM support via `ModelProvider` enum and `get_langchain_chat_model()` factory
- Integrate MiniMax as a provider using OpenAI-compatible API via `langchain_openai.ChatOpenAI`
- Default model: `MiniMax-M3` (latest flagship: 512K context, up to 128K output, image input support)
- Users can still select `MiniMax-M2.7` or `MiniMax-M2.7-highspeed` via the `model` parameter

## Changes
- `helper_functions.py`: Add `MINIMAX` to `ModelProvider` enum, add MiniMax branch in factory function with `MiniMax-M3` as default
- `README.md`: Document MiniMax provider usage, API key requirement, and example code (default is `MiniMax-M3`; `MiniMax-M2.7` remains available via the `model` parameter)

## Why
`MiniMax-M3` is the latest flagship model, with a 512K context window, up to 128K max output, and image input support. `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` are still selectable for users who prefer the previous generation.

## Testing
- Unit tested: default model is `MiniMax-M3`, model override (e.g. `MiniMax-M2.7`) works, API base URL correct
- Integration tested with MiniMax API

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added MiniMax provider support and expanded multi-provider LLM switching across OpenAI, Groq, Anthropic, and Amazon Bedrock.

* **Documentation**
  * Added a single "Multi-Provider LLM Support" guide with provider/configuration details, required environment variables, and Python usage examples for OpenAI, MiniMax, and Anthropic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->