### PR TITLE
Clean up README: remove Technologies section, fix broken table header

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,24 +136,14 @@ Whether you're an expert or just starting out, your insights can shape the futur
 - 🛠️ Practical implementation guidelines
 - 🌟 Regular updates with the latest advancements
 
-## Technologies and Frameworks 🛠️
-
-This repository leverages cutting-edge frameworks and tools to build production-ready RAG systems:
-
-- **PydanticAI** - A Python framework for building agentic AI applications with type safety and structured outputs. PydanticAI provides seamless integration with LLMs while ensuring data validation through Pydantic models, making it ideal for production RAG systems that require reliable, type-safe agent workflows.
-- **LangChain** - Comprehensive framework for developing LLM applications with powerful abstractions for building RAG pipelines
-- **LlamaIndex** - Data framework for LLM applications with focus on data ingestion and retrieval optimization
-- **Contextual AI** - Managed platform for production-ready agentic RAG with enterprise-grade parsing and grounded LLMs
-
 ## Advanced Techniques
 
 Explore our extensive list of cutting-edge RAG techniques:
 
-| # | Category | Technique | View |
-|---|
-> **Recently added:** MemoRAG (memory-augmented retrieval), End-to-End RAG Evaluation, Open-RAG-Eval, JSON RAG | **42 notebooks** and growing
+> **Recently added:** MemoRAG (memory-augmented retrieval), End-to-End RAG Evaluation, Open-RAG-Eval, JSON RAG. **42 notebooks** and growing.
 
-----------|-----------|------|
+| # | Category | Technique | View |
+|---|----------|-----------|------|
 | 1 | Foundational 🌱 | Basic RAG | [<img src="https://img.shields.io/badge/GitHub-View-blue" height="20">](https://github.com/NirDiamant/RAG_TECHNIQUES/blob/main/all_rag_techniques/simple_rag.ipynb) [<img src="https://colab.research.google.com/assets/colab-badge.svg" height="20">](https://colab.research.google.com/github/NirDiamant/RAG_Techniques/blob/main/all_rag_techniques/simple_rag.ipynb) |
 | 2 | Foundational 🌱 | RAG with CSV Files | [<img src="https://img.shields.io/badge/GitHub-View-blue" height="20">](https://github.com/NirDiamant/RAG_TECHNIQUES/blob/main/all_rag_techniques/simple_csv_rag.ipynb) [<img src="https://colab.research.google.com/assets/colab-badge.svg" height="20">](https://colab.research.google.com/github/NirDiamant/RAG_Techniques/blob/main/all_rag_techniques/simple_csv_rag.ipynb) |
 | 3 | Foundational 🌱 | Reliable RAG | [<img src="https://img.shields.io/badge/GitHub-View-blue" height="20">](https://github.com/NirDiamant/RAG_TECHNIQUES/blob/main/all_rag_techniques/reliable_rag.ipynb) [<img src="https://colab.research.google.com/assets/colab-badge.svg" height="20">](https://colab.research.google.com/github/NirDiamant/RAG_Techniques/blob/main/all_rag_techniques/reliable_rag.ipynb) |


### PR DESCRIPTION
Two small unrelated cleanups in one PR:

## 1. Remove Technologies and Frameworks section

Removed the `## Technologies and Frameworks 🛠️` block (4 bullets:
PydanticAI, LangChain, LlamaIndex, Contextual AI). The notebooks in
this repo are not tied to those specific frameworks, and the section
was adding noise rather than value.

## 2. Fix broken Advanced Techniques table header

The table header was malformed, breaking the table's rendering
entirely. The broken source:

```
| # | Category | Technique | View |
|---|
> **Recently added:** MemoRAG ... | **42 notebooks** and growing

----------|-----------|------|
```

Three things were wrong:
- The column separator row `|---|` only had one column defined (the
  table has four columns, so it needs three more `|...|` segments)
- The `> **Recently added:**` blockquote was wedged inside the header
  section, where markdown parsers do not expect blockquote syntax
- The remainder of the separator row `----------|-----------|------|`
  was orphaned on its own line, disconnected from the opening `|---|`

The fix extracts the blockquote to its own line above the table (with
a cleaner period separator instead of a `|`), and restores a proper
4-column separator row.

After the fix, the table renders correctly with all ~42 rows. Net diff:
3 insertions, 13 deletions (the README gets smaller, not larger).

## What does NOT change

- Zero content in the Advanced Techniques table itself is modified
- The existing book promotion at the top of the README is untouched
- All other sections are untouched
- This PR is completely independent of #134 (Recommended Reading)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
- Updated README with refined content and improved formatting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->