### PR TITLE
Update book pricing to $9.99 + add PE Book countdown banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,15 +10,27 @@
 
 Built on top of everything in this repo, the book goes far deeper: the **intuition** behind every technique, **side-by-side comparisons** of when each one wins (and when it quietly fails), and **illustrations** that make the tricky parts finally click.
 
-### ⏳ **Free with Kindle Unlimited** or **$0.99** launch price
+### **Free with Kindle Unlimited** or **$9.99** on Amazon
 
-The price goes up once the launch window closes. Readers who grab it now lock in the lowest price it will ever have, and get the same material that took months of research, writing, and iteration to put together.
-
-### 👉 [**Get the book on Amazon before the price changes**](https://europe-west1-rag-techniques-views-tracker.cloudfunctions.net/rag-techniques-tracker?notebook=main-readme&click=book-buy-amazon-cta&target=https%3A%2F%2Fwww.amazon.com%2Fdp%2FB0D76734SZ%3Ftag%3Ddiamantai-ragrm-20&text=Get%20the%20book%20on%20Amazon%20before%20the%20price%20changes)
+### 👉 [**Get the book on Amazon**](https://europe-west1-rag-techniques-views-tracker.cloudfunctions.net/rag-techniques-tracker?notebook=main-readme&click=book-buy-amazon-cta&target=https%3A%2F%2Fwww.amazon.com%2Fdp%2FB0D76734SZ%3Ftag%3Ddiamantai-ragrm-20&text=Get%20the%20book%20on%20Amazon)
 
 </div>
 
 ---
+
+
+<div align="center">
+
+### 🔥 This week only: companion book on Kindle Countdown Deal
+
+The series prerequisite, **Prompt Engineering: Master the Art of AI Interaction**, is on a Kindle Countdown Deal at **$2.99** through April 21. Strengthen your prompting foundations before working through the RAG techniques.
+
+### 👉 [**Get Prompt Engineering at countdown pricing**](https://europe-west1-rag-techniques-views-tracker.cloudfunctions.net/rag-techniques-tracker?notebook=main-readme&click=book-buy-pe-countdown&target=https%3A%2F%2Fwww.amazon.com%2Fdp%2FB0DZ85RPB5%3Ftag%3Ddiamantai-ragrm-20&text=Get%20Prompt%20Engineering%20at%20countdown%20pricing)
+
+</div>
+
+---
+
 
 
 


### PR DESCRIPTION
Removes the now-stale "$0.99 launch price" messaging and updates the
RAG Made Simple promotion to reflect its current steady-state price
of $9.99 (free with Kindle Unlimited).

The book launched at $0.99 on April 9 as a rank-buying promotional
period. The price was raised to $9.99 on April 13. Existing README
copy was still showing the $0.99 launch price and time-limited urgency
language ("price goes up soon", "before the price changes"), which is
no longer accurate.

Changes are minimal and surgical. No structural changes to the README.
The existing book promotion section retains its layout, image, click-
tracker URL, and Amazon Associates affiliate tag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* **Updated primary book purchase callout** with new pricing information and a direct Amazon purchase link
* **Added promotional content** for a companion book featuring a Kindle Countdown Deal and updated availability messaging

<!-- end of auto-generated comment: release notes by coderabbit.ai -->