### PR TITLE
Revert RAG book to $0.99 launch pricing

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,11 @@
 
 Built on top of everything in this repo, the book goes far deeper: the **intuition** behind every technique, **side-by-side comparisons** of when each one wins (and when it quietly fails), and **illustrations** that make the tricky parts finally click.
 
-### **Free with Kindle Unlimited** or **$9.99** on Amazon
+### ⏳ **Free with Kindle Unlimited** or **$0.99** launch price
 
-### 👉 [**Get the book on Amazon**](https://europe-west1-rag-techniques-views-tracker.cloudfunctions.net/rag-techniques-tracker?notebook=main-readme&click=book-buy-amazon-cta&target=https%3A%2F%2Fwww.amazon.com%2Fdp%2FB0D76734SZ%3Ftag%3Ddiamantai-ragrm-20&text=Get%20the%20book%20on%20Amazon)
+The price goes up once the launch window closes. Readers who grab it now lock in the lowest price it will ever have, and get the same material that took months of research, writing, and iteration to put together.
+
+### 👉 [**Get the book on Amazon before the price changes**](https://europe-west1-rag-techniques-views-tracker.cloudfunctions.net/rag-techniques-tracker?notebook=main-readme&click=book-buy-amazon-cta&target=https%3A%2F%2Fwww.amazon.com%2Fdp%2FB0D76734SZ%3Ftag%3Ddiamantai-ragrm-20&text=Get%20the%20book%20on%20Amazon%20before%20the%20price%20changes)
 
 </div>
 


### PR DESCRIPTION
Reverts the RAG Made Simple promotion to launch pricing ($0.99).

The book was briefly raised to $9.99 on Apr 13 to prep for a Kindle
Countdown Deal, but that triggered KDP's 30-day list price stability
rule which blocked the countdown. The price has been restored to
$0.99 for the rest of the launch window; the book will move to steady
state pricing at a later date.

PE Book countdown remains active at $2.99 through April 21 (PE Book
was eligible because it's been at $9.99 for over a year).

No structural changes to the README. Only the pricing copy is
reverted to match the original launch message.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated book promotional pricing information with new launch pricing details.
  * Added clarification that pricing will increase post-launch, encouraging early adoption.
  * Enhanced call-to-action messaging to reflect the limited-time offer window.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->