### PR TITLE
docs: refresh book promo - remove stale launch pricing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,33 +1,24 @@
 <div align="center">
 
-# 📖 [The RAG Techniques Book is HERE](https://europe-west1-rag-techniques-views-tracker.cloudfunctions.net/rag-techniques-tracker?notebook=main-readme&click=book-buy-amazon-title&target=https%3A%2F%2Fwww.amazon.com%2Fdp%2FB0D76734SZ%3Ftag%3Ddiamantai-ragrm-20&text=The%20RAG%20Techniques%20Book%20is%20HERE)
+# 📖 [RAG Made Simple: the book that extends this repo](https://europe-west1-rag-techniques-views-tracker.cloudfunctions.net/rag-techniques-tracker?notebook=main-readme&click=book-buy-amazon-title&target=https%3A%2F%2Fwww.amazon.com%2Fdp%2FB0D76734SZ%3Ftag%3Ddiamantai-ragrm-20&text=RAG%20Made%20Simple)
 
-### The super extended version of this repository
+<a href="https://europe-west1-rag-techniques-views-tracker.cloudfunctions.net/rag-techniques-tracker?notebook=main-readme&click=book-buy-amazon-image&target=https%3A%2F%2Fwww.amazon.com%2Fdp%2FB0D76734SZ%3Ftag%3Ddiamantai-ragrm-20&text=Best%20Seller%20Image"><img src="images/rag_book_best_seller.png" alt="RAG Made Simple - Amazon bestseller in Generative AI" width="600"></a>
 
-<a href="https://europe-west1-rag-techniques-views-tracker.cloudfunctions.net/rag-techniques-tracker?notebook=main-readme&click=book-buy-amazon-image&target=https%3A%2F%2Fwww.amazon.com%2Fdp%2FB0D76734SZ%3Ftag%3Ddiamantai-ragrm-20&text=Best%20Seller%20Image"><img src="images/rag_book_best_seller.png" alt="#1 Best Seller in Generative AI on Amazon - Click to buy" width="600"></a>
+The full reference: a 400-page visual guide that goes deeper than any notebook can. The **intuition** behind every technique, **side-by-side comparisons** of when each one wins (and when it quietly fails), and **diagrams** that make the tricky parts finally click.
 
-**#1 Best Seller on Amazon in Generative AI**
+**1,500+ copies sold · Hit #1 in Generative AI on Amazon at launch · ⭐ 4.4 stars**
 
-Built on top of everything in this repo, the book goes far deeper: the **intuition** behind every technique, **side-by-side comparisons** of when each one wins (and when it quietly fails), and **illustrations** that make the tricky parts finally click.
+📖 **Kindle $9.99 · Paperback $24.99 · Free with Kindle Unlimited**
 
-### ⏳ **Free with Kindle Unlimited** or **$0.99** launch price
-
-The price goes up once the launch window closes. Readers who grab it now lock in the lowest price it will ever have, and get the same material that took months of research, writing, and iteration to put together.
-
-### 👉 [**Get the book on Amazon before the price changes**](https://europe-west1-rag-techniques-views-tracker.cloudfunctions.net/rag-techniques-tracker?notebook=main-readme&click=book-buy-amazon-cta&target=https%3A%2F%2Fwww.amazon.com%2Fdp%2FB0D76734SZ%3Ftag%3Ddiamantai-ragrm-20&text=Get%20the%20book%20on%20Amazon%20before%20the%20price%20changes)
-
-</div>
+### 👉 [**Get the book on Amazon**](https://europe-west1-rag-techniques-views-tracker.cloudfunctions.net/rag-techniques-tracker?notebook=main-readme&click=book-buy-amazon-cta&target=https%3A%2F%2Fwww.amazon.com%2Fdp%2FB0D76734SZ%3Ftag%3Ddiamantai-ragrm-20&text=Get%20the%20book%20on%20Amazon)
 
 ---
 
+#### Companion: Prompt Engineering, Master the Art of AI Interaction
 
-<div align="center">
+The prompting foundation that makes RAG work better. Same author, same visual approach. 22 hands-on techniques explained with the same depth as the RAG book.
 
-### 🔥 This week only: companion book on Kindle Countdown Deal
-
-The series prerequisite, **Prompt Engineering: Master the Art of AI Interaction**, is on a Kindle Countdown Deal at **$2.99** through April 21. Strengthen your prompting foundations before working through the RAG techniques.
-
-### 👉 [**Get Prompt Engineering at countdown pricing**](https://europe-west1-rag-techniques-views-tracker.cloudfunctions.net/rag-techniques-tracker?notebook=main-readme&click=book-buy-pe-countdown&target=https%3A%2F%2Fwww.amazon.com%2Fdp%2FB0DZ85RPB5%3Ftag%3Ddiamantai-ragrm-20&text=Get%20Prompt%20Engineering%20at%20countdown%20pricing)
+👉 [**See Prompt Engineering on Amazon**](https://europe-west1-rag-techniques-views-tracker.cloudfunctions.net/rag-techniques-tracker?notebook=main-readme&click=book-buy-pe&target=https%3A%2F%2Fwww.amazon.com%2Fdp%2FB0DZ85RPB5%3Ftag%3Ddiamantai-ragrm-20&text=See%20Prompt%20Engineering)
 
 </div>
 


### PR DESCRIPTION
## Summary

The top README section advertised the Kindle book at "\$0.99 launch price" with "price goes up soon" urgency. The actual Kindle price was raised to \$9.99 on May 16. Visitors clicking through were seeing a different price than promised, hurting conversion and trust.

Also removed the "🔥 This week only" Countdown Deal section for Prompt Engineering, which referenced a deal that ended April 21 (5+ weeks ago).

## What changed

- Replaced launch-window copy with evergreen value prop
- Updated to current pricing: Kindle \$9.99, Paperback \$24.99, Free with KU
- Used verifiable social proof: 1,500+ sold, hit #1 in Gen AI at launch, 4.4 stars
- Kept bestseller image (documents real past achievement; still accurate framing)
- Restructured Prompt Engineering cross-promo as evergreen series companion
- **Preserved all existing click-tracker URLs and affiliate tags** (analytics intact)

## Why this matters

The old copy created a bait-and-switch perception:
- Visitor sees "\$0.99 launch price" claim
- Clicks through expecting \$0.99
- Sees \$9.99 on Amazon
- Bounces / loses trust

New copy sets correct expectations and uses real social proof.

## Verification

- All tracker URLs match existing format (notebook=main-readme, click=book-buy-*)
- Affiliate tags preserved: diamantai-ragrm-20
- No layout changes outside the book promo block

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated book promotion messaging
  * Replaced prior book launch content with new "RAG Made Simple" highlight including updated affiliate links and pricing callouts
  * Removed time-limited deal section
  * Refreshed companion book section with updated tracking links

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NirDiamant/RAG_Techniques/pull/144?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->