### PR TITLE
Add affiliate CTA for content creators

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ The full reference: a 400-page visual guide that goes deeper than any notebook c
 
 ### 👉 [**Get RAG Made Simple (33% off with code RAGKING)**](https://diamant-ai.com/rag-made-simple?code=RAGKING)
 
+📣 *Teach, write, or run a dev community? Earn 30% recommending RAG Made Simple to your audience: [become an affiliate](https://nirdiamant.gumroad.com/affiliates).*
+
 ---
 
 #### Companion: Prompt Engineering, Master the Art of AI Interaction


### PR DESCRIPTION
Adds a targeted affiliate-recruitment line under the existing book CTA. Framed for people with their own audience (educators, writers, community leaders) so it self-selects promoters rather than waving a discount at direct buyers. Signup: https://nirdiamant.gumroad.com/affiliates

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new affiliate partnership call-to-action in the README's promotional section, inviting readers to become affiliates for recommending "RAG Made Simple."

<!-- end of auto-generated comment: release notes by coderabbit.ai -->