### PR TITLE
Set affiliate CTA rate to 25%

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The full reference: a 400-page visual guide that goes deeper than any notebook c
 
 ### 👉 [**Get RAG Made Simple (33% off with code RAGKING)**](https://diamant-ai.com/rag-made-simple?code=RAGKING)
 
-📣 *Teach, write, or run a dev community? Earn 30% recommending RAG Made Simple to your audience: [become an affiliate](https://europe-west1-rag-techniques-views-tracker.cloudfunctions.net/rag-techniques-tracker?notebook=main-readme&click=affiliate-signup&target=https%3A%2F%2Fnirdiamant.gumroad.com%2Faffiliates&retarget=0&text=become%20an%20affiliate).*
+📣 *Teach, write, or run a dev community? Earn 25% recommending RAG Made Simple to your audience: [become an affiliate](https://europe-west1-rag-techniques-views-tracker.cloudfunctions.net/rag-techniques-tracker?notebook=main-readme&click=affiliate-signup&target=https%3A%2F%2Fnirdiamant.gumroad.com%2Faffiliates&retarget=0&text=become%20an%20affiliate).*
 
 ---
 


### PR DESCRIPTION
Lowers the displayed affiliate rate 30% -> 25% to match the Gumroad signup form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated affiliate discount offer from 30% to 25% with corresponding tracking parameter adjustments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->