### PR TITLE
Fix deprecated get_relevant_documents, use invoke instead

### DIFF
--- a/helper_functions.py
+++ b/helper_functions.py
@@ -140,7 +140,7 @@ def retrieve_context_per_question(question, chunks_query_retriever):
     """
 
     # Retrieve relevant documents for the given question
-    docs = chunks_query_retriever.get_relevant_documents(question)
+    docs = chunks_query_retriever.invoke(question)
 
     # Concatenate document content
     # context = " ".join(doc.page_content for doc in docs)


### PR DESCRIPTION
/content/RAG_TECHNIQUES/helper_functions.py:143: LangChainDeprecationWarning: The method `BaseRetriever.get_relevant_documents` was deprecated in langchain-core 0.1.46 and will be removed in 1.0. Use :meth:`~invoke` instead.
  docs = chunks_query_retriever.get_relevant_documents(question)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal document retrieval mechanism to improve efficiency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->